### PR TITLE
Move backend behind an interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,10 @@ name = "fishsticks"
 version = "0.1.1"
 edition = "2018"
 
-[dependencies]
-sdl2 = { git = "https://github.com/Rust-SDL2/rust-sdl2" }
-
 [features]
 bundled-sdl2 = ["sdl2/bundled"]
+
+[dependencies]
+cfg-if = "1.0.0"
+#gilrs = { version = "0.8.1", optional = true }
+sdl2 = { git = "https://github.com/Rust-SDL2/rust-sdl2" }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,0 +1,21 @@
+cfg_if::cfg_if! {
+    if #[cfg(feature = "gilrs")] {
+        compile_error!("gilrs not yet implemented");
+    } else {
+        // SDL2 has the highest compatibility of all game input libraries,
+        // so it should be the default implementation.
+        #[path = "backend/sdl2.rs"]
+        mod implementation;
+    }
+}
+pub use implementation::*;
+
+use std::collections::HashMap;
+
+pub trait GamepadSystem {
+    fn update(&mut self, gamepads: &mut HashMap<GamepadId, super::Gamepad>) -> Result<(), String>;
+}
+
+pub trait Detachable {
+    fn connected(&self) -> bool;
+}

--- a/src/backend/sdl2.rs
+++ b/src/backend/sdl2.rs
@@ -1,0 +1,100 @@
+pub use sdl2::controller::{Axis, Button};
+
+use crate::analog::AnalogInputValue;
+use std::collections::HashMap;
+
+/// The instance Id of a gamepad.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GamepadId(u32);
+
+pub struct Gamepad(sdl2::controller::GameController);
+
+impl super::Detachable for Gamepad {
+    fn connected(&self) -> bool {
+        self.0.attached()
+    }
+}
+
+pub struct GamepadContext {
+    sdl_context: sdl2::Sdl,
+    controller_subsystem: sdl2::GameControllerSubsystem,
+}
+
+impl GamepadContext {
+    pub fn init() -> Result<Self, String> {
+        let sdl_context = sdl2::init()?;
+        let controller_subsystem = sdl_context.game_controller()?;
+
+        Ok(Self {
+            sdl_context,
+            controller_subsystem,
+        })
+    }
+}
+
+impl super::GamepadSystem for GamepadContext {
+    fn update(&mut self, gamepads: &mut HashMap<GamepadId, crate::Gamepad>) -> Result<(), String> {
+        let mut event_pump = self.sdl_context.event_pump()?;
+
+        for (_, gamepad) in gamepads.iter_mut() {
+            gamepad.update_inputs();
+        }
+
+        for event in event_pump.poll_iter() {
+            use sdl2::event::Event;
+            match event {
+                Event::ControllerDeviceAdded { which, .. } => {
+                    let gamepad = self.controller_subsystem.open(which);
+                    if let Ok(gamepad) = gamepad {
+                        #[cfg(debug_assertions)]
+                        let name = gamepad.name();
+
+                        gamepads.insert(
+                            GamepadId(gamepad.instance_id()),
+                            crate::Gamepad::new(Gamepad(gamepad)),
+                        );
+
+                        #[cfg(debug_assertions)]
+                        println!("Added gamepad \"{}\"", name);
+                    }
+                }
+                Event::ControllerDeviceRemoved { which, .. } => {
+                    #[cfg(debug_assertions)]
+                    let name = gamepads
+                        .get(&GamepadId(which))
+                        .unwrap()
+                        .internal_gamepad
+                        .0
+                        .name();
+
+                    gamepads.remove(&GamepadId(which));
+
+                    #[cfg(debug_assertions)]
+                    println!("Removed gamepad \"{}\"", name);
+                }
+                Event::ControllerAxisMotion {
+                    which, axis, value, ..
+                } => {
+                    if let Some(gamepad) = gamepads.get_mut(&GamepadId(which)) {
+                        gamepad
+                            .analog_inputs
+                            .set(axis, AnalogInputValue::from(value));
+                    }
+                }
+                Event::ControllerButtonDown { which, button, .. } => {
+                    if let Some(gamepad) = gamepads.get_mut(&GamepadId(which)) {
+                        gamepad.digital_inputs.activate(button);
+                    }
+                }
+                Event::ControllerButtonUp { which, button, .. } => {
+                    if let Some(gamepad) = gamepads.get_mut(&GamepadId(which)) {
+                        gamepad.digital_inputs.deactivate(button);
+                    }
+                }
+                _ => (),
+            }
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Fixes #5.

I left `Axis` and `Button` public for the sake of simplicity, but they can be placed behind wrappers in the future if we want to support users changing the backend arbitrarily.

`GamepadId` is public as well, but the SDL2 implementation already defines it as a wrapper anyways, and I saw no reason to put a wrapper around a wrapper. One alternative is to define a type alias in the implementation instead of a wrapper. Then, `GamepadId` can be defined in the crate root as a wrapper around the implementation's id.