### PR TITLE
Add gilrs implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ bundled-sdl2 = ["sdl2/bundled"]
 
 [dependencies]
 cfg-if = "1.0.0"
-#gilrs = { version = "0.8.1", optional = true }
+gilrs = { version = "0.8.1", optional = true }
 sdl2 = "0.35.0"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,6 +1,7 @@
 cfg_if::cfg_if! {
     if #[cfg(feature = "gilrs")] {
-        compile_error!("gilrs not yet implemented");
+        #[path = "backend/gilrs.rs"]
+        mod implementation;
     } else {
         // SDL2 has the highest compatibility of all game input libraries,
         // so it should be the default implementation.
@@ -18,8 +19,4 @@ use crate::Result;
 
 pub trait Backend {
     fn update(&mut self, gamepads: &mut HashMap<GamepadId, Gamepad>) -> Result<()>;
-}
-
-pub trait BackendGamepad {
-    fn connected(&self) -> bool;
 }

--- a/src/backend/gilrs.rs
+++ b/src/backend/gilrs.rs
@@ -1,0 +1,70 @@
+pub use gilrs::{Axis, Button};
+
+use crate::analog::AnalogInputValue;
+use crate::{Gamepad, GamepadId};
+use std::collections::HashMap;
+
+use crate::Result;
+
+pub type ImplementationId = gilrs::GamepadId;
+
+pub struct OwnedImplementationGamepad;
+
+pub struct ImplementationContext {
+    context: gilrs::Gilrs,
+}
+
+impl ImplementationContext {
+    pub fn new() -> Result<Self> {
+        match gilrs::Gilrs::new() {
+            Ok(context) => Ok(Self { context }),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+}
+
+impl super::Backend for ImplementationContext {
+    fn update(&mut self, gamepads: &mut HashMap<GamepadId, Gamepad>) -> Result<()> {
+        for (_, gamepad) in gamepads.iter_mut() {
+            gamepad.update_inputs();
+        }
+
+        while let Some(gilrs::Event { id, event, .. }) = self.context.next_event() {
+            use gilrs::EventType;
+            match event {
+                EventType::Connected => {
+                    gamepads.insert(GamepadId(id), Gamepad::new());
+
+                    #[cfg(debug_assertions)]
+                    println!("Added gamepad \"{}\"", self.context.gamepad(id).name());
+                }
+                EventType::Disconnected => {
+                    gamepads.remove(&GamepadId(id));
+
+                    #[cfg(debug_assertions)]
+                    println!("Removed gamepad \"{}\"", self.context.gamepad(id).name());
+                }
+                EventType::AxisChanged(axis, value, _) => {
+                    if let Some(gamepad) = gamepads.get_mut(&GamepadId(id)) {
+                        gamepad
+                            .analog_inputs
+                            .set(axis, AnalogInputValue::from(value));
+                    }
+                }
+                EventType::ButtonPressed(button, _) => {
+                    if let Some(gamepad) = gamepads.get_mut(&GamepadId(id)) {
+                        gamepad.digital_inputs.activate(button);
+                    }
+                }
+                EventType::ButtonReleased(button, _) => {
+                    if let Some(gamepad) = gamepads.get_mut(&GamepadId(id)) {
+                        gamepad.digital_inputs.deactivate(button);
+                    }
+                }
+                _ => (),
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/backend/sdl2.rs
+++ b/src/backend/sdl2.rs
@@ -8,13 +8,7 @@ use crate::Result;
 
 pub type ImplementationId = u32;
 
-pub struct ImplementationGamepad(sdl2::controller::GameController);
-
-impl super::BackendGamepad for ImplementationGamepad {
-    fn connected(&self) -> bool {
-        self.0.attached()
-    }
-}
+pub struct OwnedImplementationGamepad(sdl2::controller::GameController);
 
 pub struct ImplementationContext {
     sdl_context: sdl2::Sdl,
@@ -52,7 +46,8 @@ impl super::Backend for ImplementationContext {
 
                         gamepads.insert(
                             GamepadId(gamepad.instance_id()),
-                            Gamepad::new(ImplementationGamepad(gamepad)),
+                            Gamepad::new()
+                                .insert_owned_gamepad(OwnedImplementationGamepad(gamepad)),
                         );
 
                         #[cfg(debug_assertions)]
@@ -64,7 +59,9 @@ impl super::Backend for ImplementationContext {
                     let name = gamepads
                         .get(&GamepadId(which))
                         .unwrap()
-                        .internal_gamepad
+                        .owned_internal_gamepad
+                        .as_ref()
+                        .unwrap()
                         .0
                         .name();
 


### PR DESCRIPTION
Fixes #7.

This addresses the lifetime issue described in #12 but uses an alternative solution. We only store the implementation gamepads if the implementation requires us to own them, as is the case with SDL2. If the implementation owns and manages its gamepads, as is the case with gilrs, then we have no need to store them, since we can just query the implementation's context to retrieve references to the gamepads.