### PR TITLE
Make SDL2 an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,10 @@ version = "0.1.1"
 edition = "2018"
 
 [features]
+default = ["sdl2"]
 bundled-sdl2 = ["sdl2/bundled"]
 
 [dependencies]
 cfg-if = "1.0.0"
 gilrs = { version = "0.8.1", optional = true }
-sdl2 = "0.35.0"
+sdl2 = { version = "0.35.1", optional = true }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,11 +1,12 @@
 cfg_if::cfg_if! {
-    if #[cfg(feature = "gilrs")] {
+    if #[cfg(feature = "sdl2")] {
+        #[path = "backend/sdl2.rs"]
+        mod implementation;
+    } else if #[cfg(feature = "gilrs")] {
         #[path = "backend/gilrs.rs"]
         mod implementation;
     } else {
-        // SDL2 has the highest compatibility of all game input libraries,
-        // so it should be the default implementation.
-        #[path = "backend/sdl2.rs"]
+        #[path = "backend/dummy.rs"]
         mod implementation;
     }
 }

--- a/src/backend/dummy.rs
+++ b/src/backend/dummy.rs
@@ -1,0 +1,36 @@
+compile_error!("no gamepad backend chosen");
+
+// The sole purpose of everything below this comment is to supress
+// irrelevant warnings and errors. All of it is dead code.
+
+use crate::{Gamepad, GamepadId};
+use std::collections::HashMap;
+
+use crate::Result;
+
+/// Dummy axis.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Axis {}
+
+/// Dummy button.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Button {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ImplementationId {}
+
+pub enum OwnedImplementationGamepad {}
+
+pub struct ImplementationContext;
+
+impl ImplementationContext {
+    pub fn new() -> Result<Self> {
+        Err("Dummy context".into())
+    }
+}
+
+impl super::Backend for ImplementationContext {
+    fn update(&mut self, _: &mut HashMap<GamepadId, Gamepad>) -> Result<()> {
+        Err("Dummy context".into())
+    }
+}

--- a/src/backend/gilrs.rs
+++ b/src/backend/gilrs.rs
@@ -8,7 +8,7 @@ use crate::Result;
 
 pub type ImplementationId = gilrs::GamepadId;
 
-pub struct OwnedImplementationGamepad;
+pub enum OwnedImplementationGamepad {}
 
 pub struct ImplementationContext {
     context: gilrs::Gilrs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,10 @@
-//! System for handling gamepad input.
+//! Wrapper library for handling gamepad input. API is unstable and may change at any time.
 //!
-//! API is unstable and may change at any time.
-//! Uses SDL2 as the backend.
+//! Uses SDL2 as the backend by default.
+//! To use gilrs instead, disable default features and enable the `gilrs` feature.
 
 #![warn(missing_docs)]
+#![cfg_attr(not(any(feature = "sdl2", feature = "gilrs")), allow(dead_code))]
 
 pub mod analog;
 pub mod digital;


### PR DESCRIPTION
Previously, users choosing the gilrs implementation were forced to compile SDL2, even when it was not used. Now, they can avoid this by disabling default features.